### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Using completely custom view
 
 You can use any icon provided by [Android-Iconify](https://github.com/JoanZapata/android-iconify) library
 
-#Credits
+# Credits
 - [Joan Zapata](https://github.com/JoanZapata)  The creator of [Android-Iconify](https://github.com/JoanZapata/android-iconify)
 - [Pierry Borges](https://github.com/Pierry/SimpleToast) Thanks for the idea
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
